### PR TITLE
fix(auto-spies-core): don't add getters to method names when creating spies from class

### DIFF
--- a/packages/auto-spies-core/src/create-auto-spy-from-class.ts
+++ b/packages/auto-spies-core/src/create-auto-spy-from-class.ts
@@ -85,16 +85,20 @@ function getAllMethodNames(obj: any): string[] {
     const parentObj = Object.getPrototypeOf(obj);
     // we don't want to spy on Function.prototype methods
     if (parentObj) {
-      methods = methods.concat(Object.getOwnPropertyNames(obj));
+      methods = methods.concat(extractMethodsFromObject(obj));
     }
     obj = parentObj;
   }
-
-  const constructorIndex = methods.indexOf('constructor');
-
-  /* istanbul ignore else */
-  if (constructorIndex >= 0) {
-    methods.splice(constructorIndex, 1);
-  }
   return methods;
+}
+
+function extractMethodsFromObject(obj: any) {
+  const propertyDescriptors = Object.getOwnPropertyDescriptors(obj);
+  return Object.keys(propertyDescriptors).reduce((names, name) => {
+    const descriptor = propertyDescriptors[name];
+    if (name !== 'constructor' && !descriptor.get) {
+      names.push(name);
+    }
+    return names;
+  }, [] as string[]);
 }

--- a/packages/jasmine-auto-spies/src/tests/fake-classes-to-test.ts
+++ b/packages/jasmine-auto-spies/src/tests/fake-classes-to-test.ts
@@ -5,6 +5,10 @@ export class FakeClass {
   public someProp: number = 1;
   public observableProp: Observable<any> = new Observable();
 
+  public get observablePropAsGetter() {
+    return this.observableProp;
+  }
+
   public getSyncValue(): string {
     return '';
   }

--- a/packages/jasmine-auto-spies/src/tests/observable-spy-utils.spec.ts
+++ b/packages/jasmine-auto-spies/src/tests/observable-spy-utils.spec.ts
@@ -1,5 +1,5 @@
 import { errorHandler } from '@hirez_io/auto-spies-core';
-import { Subject, merge, ReplaySubject } from 'rxjs';
+import { Subject, merge } from 'rxjs';
 import { SubscriberSpy, subscribeSpyTo } from '@hirez_io/observer-spy';
 import { Spy } from '../jasmine-auto-spies.types';
 import { FakeClass, FakeChildClass } from './fake-classes-to-test';
@@ -593,6 +593,26 @@ describe('createSpyFromClass - Observables', () => {
         Then('return value should be the fake value', () => {
           expect(observerSpy.getLastValue()).toBe(FAKE_VALUE);
         });
+      });
+    });
+
+    describe(`GIVEN class spy with a getter returning an observable
+             WHEN calling nextWith with fake value and subscribing`, () => {
+      Given(() => {
+        fakeClassSpy = createSpyFromClass(FakeClass, {
+          observablePropsToSpyOn: ['observablePropAsGetter'],
+        });
+        fakeClassSpy.observablePropAsGetter.nextWith(FAKE_VALUE);
+      });
+
+      When(() => {
+        observerSpy = subscribeSpyTo(fakeClassSpy.observablePropAsGetter, {
+          expectErrors: errorIsExpected,
+        });
+      });
+
+      Then('return value should be the fake value', () => {
+        expect(observerSpy.getLastValue()).toBe(FAKE_VALUE);
       });
     });
 

--- a/packages/jest-auto-spies/src/tests/fake-classes-to-test.ts
+++ b/packages/jest-auto-spies/src/tests/fake-classes-to-test.ts
@@ -5,6 +5,10 @@ export class FakeClass {
   public someProp: number = 1;
   public observableProp: Observable<any> = new Observable();
 
+  public get observablePropAsGetter() {
+    return this.observableProp;
+  }
+
   public getSyncValue(): string {
     return '';
   }

--- a/packages/jest-auto-spies/src/tests/observable-spy-utils.spec.ts
+++ b/packages/jest-auto-spies/src/tests/observable-spy-utils.spec.ts
@@ -1,5 +1,5 @@
 import { errorHandler } from '@hirez_io/auto-spies-core';
-import { merge, ReplaySubject, Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { SubscriberSpy, subscribeSpyTo } from '@hirez_io/observer-spy';
 import { Spy } from '../jest-auto-spies.types';
@@ -593,6 +593,26 @@ describe('createSpyFromClass - Observables', () => {
         Then('return value should be the fake value', () => {
           expect(observerSpy.getLastValue()).toBe(FAKE_VALUE);
         });
+      });
+    });
+
+    describe(`GIVEN class spy with a getter returning an observable
+             WHEN calling nextWith with fake value and subscribing`, () => {
+      Given(() => {
+        fakeClassSpy = createSpyFromClass(FakeClass, {
+          observablePropsToSpyOn: ['observablePropAsGetter'],
+        });
+        fakeClassSpy.observablePropAsGetter.nextWith(FAKE_VALUE);
+      });
+
+      When(() => {
+        observerSpy = subscribeSpyTo(fakeClassSpy.observablePropAsGetter, {
+          expectErrors: errorIsExpected,
+        });
+      });
+
+      Then('return value should be the fake value', () => {
+        expect(observerSpy.getLastValue()).toBe(FAKE_VALUE);
       });
     });
 


### PR DESCRIPTION
fix #40