### PR TITLE
chore(package.json): allow RxJs 7 as peerDependency

### DIFF
--- a/packages/auto-spies-core/package.json
+++ b/packages/auto-spies-core/package.json
@@ -52,7 +52,7 @@
     "serialize-javascript": "5.0.1"
   },
   "peerDependencies": {
-    "rxjs": "^6.0.0",
+    "rxjs": ">=6.0.0 < 8",
     "typescript": ">=2.8.1"
   }
 }

--- a/packages/jasmine-auto-spies/package.json
+++ b/packages/jasmine-auto-spies/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "jasmine-core": ">=2.6.0 < 4",
-    "rxjs": "^6.0.0",
+    "rxjs": ">=6.0.0 < 8",
     "typescript": ">=2.8.1"
   }
 }

--- a/packages/jest-auto-spies/package.json
+++ b/packages/jest-auto-spies/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "jest": "< 28.x",
-    "rxjs": "^6.0.0",
+    "rxjs": ">=6.0.0 < 8",
     "typescript": ">=2.8.1"
   }
 }


### PR DESCRIPTION
Allow RxJs 7 as peerDependency to all three libraries.

fix #52