### PR TITLE
Pnpm lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lint:commitmsg": "commitlint -E HUSKY_GIT_PARAMS",
     "test": "lerna run test",
     "test:full": "run-s lint:fix test",
-    "postinstall": "lerna bootstrap",
     "prepare": "husky install"
   },
   "workspaces": [


### PR DESCRIPTION
pnpm-lock.yaml leads to problems during the publish of a new version because PNPM updates/re-formats the file and adds blanks / newlines.
Therefore lerna sees uncommitted changes and refuses to publish the package.

Also "lerna bootstrap" doesn't work if "useWorkspaces" is set to true in lerna.json.