### PR TITLE
fix(types): typesafety for mocked objects/functions

### DIFF
--- a/packages/auto-spies-core/src/observables/observable-spy-utils.ts
+++ b/packages/auto-spies-core/src/observables/observable-spy-utils.ts
@@ -106,7 +106,7 @@ function createReplaySubject<T>(): ReplaySubject<T> {
   return new ReplaySubject(1);
 }
 
-function addNextWithPerCall<T>(
+function addNextWithPerCall(
   objectToDecorate: any,
   returnValueContainer: ReturnValueContainer,
   onValuesPerCallConfigured: (

--- a/packages/auto-spies-core/src/observables/observable-spy.types.ts
+++ b/packages/auto-spies-core/src/observables/observable-spy.types.ts
@@ -1,18 +1,27 @@
-import { Subject } from 'rxjs';
-import { ValueConfigPerCall } from '../auto-spies-core.types';
+import { Observable, Subject } from 'rxjs';
+import { Func, ValueConfigPerCall } from '../auto-spies-core.types';
 
 export type CreateObservableAutoSpy<
   LibSpecificFunctionSpy,
   LibSpecificFunctionSpyWithObservableMethods,
-  ObservableReturnType
+  Method extends Func
 > = LibSpecificFunctionSpy &
   LibSpecificFunctionSpyWithObservableMethods &
-  AddCalledWithToObservableFunctionSpy<ObservableReturnType>;
+  AddCalledWithToObservableFunctionSpy<Method>;
 
-export type AddCalledWithToObservableFunctionSpy<ObservableReturnType> = {
-  calledWith(...args: any[]): AddObservableSpyMethods<ObservableReturnType>;
-  mustBeCalledWith(...args: any[]): AddObservableSpyMethods<ObservableReturnType>;
-};
+export type AddCalledWithToObservableFunctionSpy<Method extends Func> = Method &
+  (Method extends (...args: any[]) => infer ReturnType
+    ? ReturnType extends Observable<infer ObservableReturnType>
+      ? {
+          calledWith(
+            ...args: Parameters<Method>
+          ): AddObservableSpyMethods<ObservableReturnType>;
+          mustBeCalledWith(
+            ...args: Parameters<Method>
+          ): AddObservableSpyMethods<ObservableReturnType>;
+        }
+      : never
+    : never);
 
 export interface AddObservableSpyMethods<T> {
   nextWith(value?: T): void;

--- a/packages/auto-spies-core/src/promises/promises-spy.types.ts
+++ b/packages/auto-spies-core/src/promises/promises-spy.types.ts
@@ -1,17 +1,26 @@
-import { ValueConfigPerCall } from '../auto-spies-core.types';
+import { Func, ValueConfigPerCall } from '../auto-spies-core.types';
 
 export type CreatePromiseAutoSpy<
   LibSpecificFunctionSpy,
   LibSpecificFunctionSpyWithPromisesMethods,
-  PromiseReturnType
+  Method extends Func
 > = LibSpecificFunctionSpy &
   LibSpecificFunctionSpyWithPromisesMethods &
-  AddCalledWithToPromiseFunctionSpy<PromiseReturnType>;
+  AddCalledWithToPromiseFunctionSpy<Method>;
 
-export type AddCalledWithToPromiseFunctionSpy<PromiseReturnType> = {
-  calledWith(...args: any[]): AddPromiseSpyMethods<PromiseReturnType>;
-  mustBeCalledWith(...args: any[]): AddPromiseSpyMethods<PromiseReturnType>;
-};
+export type AddCalledWithToPromiseFunctionSpy<Method extends Func> = Method &
+  (Method extends (...args: any[]) => infer ReturnType
+    ? ReturnType extends Promise<infer PromiseReturnType>
+      ? {
+          calledWith(
+            ...args: Parameters<Method>
+          ): AddPromiseSpyMethods<PromiseReturnType>;
+          mustBeCalledWith(
+            ...args: Parameters<Method>
+          ): AddPromiseSpyMethods<PromiseReturnType>;
+        }
+      : never
+    : never);
 
 export interface AddPromiseSpyMethods<T> {
   resolveWith(value?: T): void;

--- a/packages/jasmine-auto-spies/src/create-function-spy.ts
+++ b/packages/jasmine-auto-spies/src/create-function-spy.ts
@@ -5,7 +5,7 @@ type JasmineCalledWithObject = { returnValue: (...args: any[]) => void };
 
 export function createFunctionSpy<FunctionType extends Func>(
   name: string
-): AddSpyMethodsByReturnTypes<FunctionType, jasmine.Spy> {
+): AddSpyMethodsByReturnTypes<FunctionType> {
   return createFunctionAutoSpy(
     name,
     addJasmineSyncMethodsToCalledWithObject,

--- a/packages/jasmine-auto-spies/src/tests/create-spy-from-class.spec.ts
+++ b/packages/jasmine-auto-spies/src/tests/create-spy-from-class.spec.ts
@@ -163,11 +163,11 @@ describe('createSpyFromClass', () => {
             WHEN called with the matching parameters`, () => {
     Given(() => {
       fakeArgs = [1, { a: 2 }];
-      fakeClassSpy.getSyncValue.calledWith(...fakeArgs).returnValue(null);
+      fakeClassSpy.getNullableSyncValue.calledWith(...fakeArgs).returnValue(null);
     });
 
     When(() => {
-      actualResult = fakeClassSpy.getSyncValue(...fakeArgs);
+      actualResult = fakeClassSpy.getNullableSyncValue(...fakeArgs);
     });
 
     Then('return null', () => {

--- a/packages/jasmine-auto-spies/src/tests/fake-classes-to-test.ts
+++ b/packages/jasmine-auto-spies/src/tests/fake-classes-to-test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Observable, of, Subject } from 'rxjs';
 
 export class FakeClass {
@@ -10,15 +11,19 @@ export class FakeClass {
     return this.observableProp;
   }
 
-  public getSyncValue(): string {
+  public getSyncValue(..._args: any[]): string {
     return '';
   }
 
-  public getPromise(): Promise<any> {
+  public getNullableSyncValue(..._args: any[]): string | null {
+    return '';
+  }
+
+  public getPromise(..._args: any[]): Promise<any> {
     return Promise.resolve();
   }
 
-  public getObservable(): Observable<any> {
+  public getObservable(..._args: any[]): Observable<any> {
     return of();
   }
 
@@ -26,7 +31,7 @@ export class FakeClass {
     return new Subject();
   }
 
-  public arrowMethod: () => void = () => {};
+  public arrowMethod: () => string = () => '';
 }
 
 export class FakeChildClass extends FakeClass {

--- a/packages/jest-auto-spies/src/create-function-spy.ts
+++ b/packages/jest-auto-spies/src/create-function-spy.ts
@@ -5,7 +5,7 @@ type JestCalledWithObject = { mockReturnValue: (...args: any[]) => void };
 
 export function createFunctionSpy<FunctionType extends Func>(
   name: string
-): AddSpyMethodsByReturnTypes<FunctionType, jasmine.Spy> {
+): AddSpyMethodsByReturnTypes<FunctionType> {
   return createFunctionAutoSpy(
     name,
     addJestSyncMethodsToCalledWithObject,

--- a/packages/jest-auto-spies/src/tests/create-spy-from-class.spec.ts
+++ b/packages/jest-auto-spies/src/tests/create-spy-from-class.spec.ts
@@ -165,11 +165,11 @@ describe('createSpyFromClass', () => {
             WHEN called with the matching parameters`, () => {
     Given(() => {
       fakeArgs = [1, { a: 2 }];
-      fakeClassSpy.getSyncValue.calledWith(...fakeArgs).mockReturnValue(null);
+      fakeClassSpy.getNullableSyncValue.calledWith(...fakeArgs).mockReturnValue(null);
     });
 
     When(() => {
-      actualResult = fakeClassSpy.getSyncValue(...fakeArgs);
+      actualResult = fakeClassSpy.getNullableSyncValue(...fakeArgs);
     });
 
     Then('return null', () => {

--- a/packages/jest-auto-spies/src/tests/fake-classes-to-test.ts
+++ b/packages/jest-auto-spies/src/tests/fake-classes-to-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Observable, of, Subject } from 'rxjs';
 
@@ -10,15 +11,19 @@ export class FakeClass {
     return this.observableProp;
   }
 
-  public getSyncValue(): string {
+  public getSyncValue(..._args: any[]): string {
     return '';
   }
 
-  public getPromise(): Promise<any> {
+  public getNullableSyncValue(..._args: any[]): string | null {
+    return '';
+  }
+
+  public getPromise(..._args: any[]): Promise<any> {
     return Promise.resolve();
   }
 
-  public getObservable(): Observable<any> {
+  public getObservable(..._args: any[]): Observable<any> {
     return of();
   }
 
@@ -26,7 +31,7 @@ export class FakeClass {
     return new Subject();
   }
 
-  public arrowMethod: () => void = () => {};
+  public arrowMethod: () => string = () => '';
 }
 
 export class FakeChildClass extends FakeClass {


### PR DESCRIPTION
functions like "mockReturnValue" and "calledWith" are now typesafe

BREAKING CHANGE: "mockReturnValue" for a function that returns a number no longer accepts something that's not a number

re #51